### PR TITLE
Fix: Downgraded Vite from 7 to 6 to be compatible with tailwindcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "sass-embedded": "^1.89.0",
     "tailwindcss": "^4.1.7",
     "typescript": "^5.4.2",
-    "vite": "^7.0.4",
+    "vite": "^6.0.0",
     "vite-plugin-electron": "^0.29.0",
     "vite-plugin-electron-renderer": "^0.14.5",
     "vite-plugin-node-polyfills": "^0.23.0",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Downgraded Vite from v7 to v6 for Tailwind compatibility after the dependabot upgrades

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] Build Out
- [ ] Import (From old Sparkplate)
- [ ] Import (From old Greenery)
- [ ] Styling
- [ ] New Feature
- [ ] New Function
- [ ] Documentation update
- [ ] Other
