### PR TITLE
Fixed up the Main tab on the About modal. Will do another pass to address the network.

### DIFF
--- a/docs/reasonings/07182025.reasoning.about.modal.layout.improvements.md
+++ b/docs/reasonings/07182025.reasoning.about.modal.layout.improvements.md
@@ -1,0 +1,93 @@
+# About Modal Layout Improvements
+
+**Date**: July 18, 2025  
+**Component**: `src/components/modals/about/Main.vue`  
+**Author**: Corey  
+
+## Problem Statement
+
+The About modal in Sparkplate needed layout improvements to better showcase the application logo while maintaining system information visibility. The original layout had the logo on the left side at a smaller size, which didn't give it enough prominence.
+
+## Solution Approach
+
+We restructured the About modal layout to:
+
+1. Move the Sparkplate logo to the right side of the modal
+2. Increase the logo size for better visibility and impact
+3. Position the system information on the left side
+4. Maintain a clean two-column layout for better visual balance
+
+## Implementation Details
+
+### Layout Structure Changes
+
+The implementation involved modifying the component's template structure from a stacked layout to a side-by-side layout with the following changes:
+
+```vue
+<div class="row">
+  <!-- Info section on the left -->
+  <div class="col-6 info-column">
+    <!-- System information content -->
+  </div>
+  
+  <!-- Logo section on the right -->
+  <div class="col-6">
+    <div class="center-content">
+      <a href="https://www.greenfire.io" target="_blank">
+        <img 
+          src="/assets/icons/greenfire/sparkplate.png" 
+          alt="sparkplate-logo" 
+          style="width: 250px; height: auto;" 
+        />
+      </a>
+    </div>
+  </div>
+</div>
+```
+
+### Styling Approach
+
+Several approaches were tested to properly size the logo:
+
+1. Initially tried CSS class-based styling with Tailwind directives:
+   ```css
+   .logo {
+     @apply max-w-[32rem] w-full h-auto;
+   }
+   ```
+
+2. Found that container constraints were limiting the logo's size, so we moved to:
+   - A full-width approach initially
+   - Then a two-column layout with direct inline styling
+   - Used explicit width in pixels to avoid any CSS inheritance issues
+
+3. Final solution used inline styling directly on the image element:
+   ```html
+   <img 
+     src="/assets/icons/greenfire/sparkplate.png" 
+     alt="sparkplate-logo" 
+     style="width: 250px; height: auto;" 
+   />
+   ```
+
+## Benefits
+
+1. **Improved Visual Hierarchy**: The logo now has more prominence while maintaining access to system information
+2. **Better Space Utilization**: The two-column layout makes better use of the available modal space
+3. **Enhanced Branding**: The larger logo reinforces the application's brand identity
+4. **Maintained Functionality**: All system information remains accessible and clearly visible
+
+## Considerations
+
+- The logo size (250px) was chosen to balance visibility with the available space in the modal
+- Inline styling was used to ensure consistent rendering across different environments
+- The layout maintains responsiveness while prioritizing the desktop viewing experience
+
+## Future Improvements
+
+Potential future enhancements could include:
+
+1. Adding responsive breakpoints for smaller screen sizes
+2. Implementing a subtle animation when the modal opens
+3. Adding hover effects to the logo link
+4. Exploring dark mode-specific styling for the modal 

--- a/src/components/modals/about/Main.vue
+++ b/src/components/modals/about/Main.vue
@@ -2,15 +2,10 @@
   <div class="main-content-wrapper">
     <div class="container-fluid">
       <div class="row">
-        <div class="col-6 logo-column">
-          <div class="center-content">
-            <a href="https://www.greenfire.io" target="_blank">
-              <img class="logo" src="/assets/icons/greenfire/sparkplate.png" alt="sparkplate-logo" />
-            </a>
-          </div>
-        </div>
+        <!-- Info section on the left -->
         <div class="col-6 info-column">
           <div>
+            <br>
             <h4 class="h3">
               <b>Sparkplate {{ appVersion }}</b>
             </h4>
@@ -28,6 +23,19 @@
               <li v-if="gpu"><b>GPU:</b> {{ gpu }}</li>
               <li v-if="datetime"><b>Date/Time:</b> {{ datetime }}</li>
             </ul>
+          </div>
+        </div>
+        
+        <!-- Logo section on the right -->
+        <div class="col-6">
+          <div class="center-content">
+            <a href="https://www.greenfire.io" target="_blank">
+              <img 
+                src="/assets/icons/greenfire/sparkplate.png" 
+                alt="sparkplate-logo" 
+                style="width: 250px; height: auto;" 
+              />
+            </a>
           </div>
         </div>
       </div>
@@ -99,19 +107,12 @@ export default {
   @apply mx-0 max-w-full;
 }
 
-.col-6 {
-  @apply px-3 max-w-[50%] break-words;
-}
-
 .center-content {
   @apply flex items-center justify-center h-full;
 }
 
-.logo {
-  @apply max-w-[14rem] h-auto;
-}
-
 .info-column {
+  @apply px-3;
   ul {
     @apply pl-4 m-0;
     


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

We improved the About modal layout by moving the Sparkplate logo to the right side and making it larger (250px width), while positioning the system information on the left side in a balanced two-column layout. This enhances the visual hierarchy, better utilizes the modal space, and strengthens brand visibility while maintaining all functional information. We implemented this using inline styling on the image element to ensure consistent rendering across environments.
### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] Build Out
- [ ] Import (From old Sparkplate)
- [x] Import (From old Greenery)
- [x] Styling
- [ ] New Feature
- [ ] New Function
- [x] Documentation update
- [ ] Other
