### PR TITLE
Added a Universe tab to the About Modal

### DIFF
--- a/docs/progress/07192025.progress.modal.about.universe.tab.md
+++ b/docs/progress/07192025.progress.modal.about.universe.tab.md
@@ -1,0 +1,118 @@
+# About Modal Universe Tab Implementation
+
+Date: July 19, 2025  
+Author: Claude  
+Component: About Modal - Universe Tab
+
+## Overview
+
+A new "Universe" tab has been added to the About modal to showcase Greenfire's ecosystem of projects. This tab provides users with information about related projects in the Greenfire universe and allows them to easily navigate to these projects' websites.
+
+## Implementation Details
+
+### 1. New Universe Component
+
+Created a new component `Universe.vue` in the `src/components/modals/about/` directory that displays:
+- Greenfire project with logo and description
+- Greenery project with logo and description
+- Techmarkets project with logo and description
+- A redacted project placeholder for future announcements
+
+### 2. About Modal Integration
+
+Updated `About.vue` to include the new Universe tab:
+- Added the Universe component to the imports and component registration
+- Added a new "universe" mode between "greenfire" and "contribute" tabs
+- Added special handling for the Universe tab to include the Greenfire logo
+- Added CSS styling for the tab icon to display inline with text
+
+### 3. Grid Layout
+
+Implemented a responsive 2x2 grid layout for the projects:
+- Used CSS Grid with 2 columns and 2 rows
+- Added appropriate spacing between grid items
+- Optimized for the available space to avoid scrolling
+- Made each card the same height for visual consistency
+
+### 4. Project Cards Design
+
+Each project card features:
+- Logo on the left side
+- Project title and description on the right
+- URL at the bottom
+- Hover effects for better user interaction
+- Click functionality to open URLs in the default browser
+
+### 5. Tab Styling
+
+Modified the tab styling to accommodate all tabs in a single row:
+- Reduced font size to prevent text wrapping
+- Added white-space: nowrap to prevent stacking
+- Reduced horizontal padding to make tabs more compact
+- Added justify-content: space-between to distribute tabs evenly
+
+### 6. Responsive Considerations
+
+Made several adjustments to ensure the component works well within the modal:
+- Optimized container sizes to eliminate scrolling
+- Used concise descriptions that convey essential information
+- Implemented text truncation for overflow handling
+- Added appropriate spacing for visual hierarchy
+
+## Technical Implementation
+
+### External URL Handling
+
+Implemented a method to open external URLs using Electron's shell API:
+```javascript
+openUrl(url) {
+  // Use electron shell to open external URL
+  if (window.shell) {
+    window.shell.openExternal(url);
+  } else if (window.open) {
+    window.open(url, '_blank');
+  }
+}
+```
+
+### CSS Grid Layout
+
+Used CSS Grid for the project layout:
+```css
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+  gap: 1rem;
+  flex: 1;
+}
+```
+
+### Tab Icon Integration
+
+Added special handling for the Universe tab to include an icon:
+```html
+<span v-if="mode === 'universe'" class="universe-tab">
+  <img src="/assets/icons/greenfire/greenfire.svg" class="tab-icon" />Universe
+</span>
+```
+
+## Testing
+
+The implementation has been tested for:
+- Proper rendering within the About modal
+- Correct tab navigation and content display
+- Hover effects and visual feedback
+- URL opening functionality
+- Layout integrity at different sizes
+
+## Next Steps
+
+1. Consider adding more detailed information about each project
+2. Add proper logos for all projects (currently using Greenfire logo as placeholder for some)
+3. Implement analytics tracking for clicks to external sites
+4. Add animation effects for tab transitions
+
+## Conclusion
+
+The Universe tab provides a clean, organized way to showcase the Greenfire ecosystem within the Sparkplate application. It enhances user awareness of related projects while maintaining a consistent visual style with the rest of the application. 

--- a/src/components/global/About.vue
+++ b/src/components/global/About.vue
@@ -26,7 +26,10 @@
             :active="mode === activeMode"
             :onClick="createSetActiveMode(mode)"
           >
-            {{ name }}
+            <span v-if="mode === 'universe'" class="universe-tab">
+              <img src="/assets/icons/greenfire/greenfire.svg" class="tab-icon" style="display: inline-block; vertical-align: middle; margin-right: 4px; margin-top: -2px;" />Universe
+            </span>
+            <template v-else>{{ name }}</template>
           </TabComponentJS>
         </TabsWrapper>
 
@@ -35,6 +38,7 @@
           <AboutMain v-if="activeMode === 'main'" />
           <Notes v-if="activeMode === 'notes'" />
           <Greenfire v-if="activeMode === 'greenfire'" />
+          <Universe v-if="activeMode === 'universe'" />
           <Contribute v-if="activeMode === 'contribute'" />
           <Donations v-if="activeMode === 'donations'" />
         </div>
@@ -47,6 +51,7 @@
 import AboutMain from '@/components/modals/about/Main.vue'
 import Notes from '@/components/modals/about/Notes.vue'
 import Greenfire from '@/components/modals/about/Greenfire.vue'
+import Universe from '@/components/modals/about/Universe.vue'
 import Contribute from '@/components/modals/about/Contribute.vue'
 import Donations from '@/components/modals/about/Donations.vue'
 import TabComponentJS from '@/components/global/TabComponentJS.vue'
@@ -54,13 +59,23 @@ import TabsWrapper from '@/components/global/TabsWrapper.vue'
 
 export default {
   name: 'AboutView',
-  components: { AboutMain, Notes, Greenfire, Contribute, Donations, TabComponentJS, TabsWrapper },
+  components: { 
+    AboutMain, 
+    Notes, 
+    Greenfire, 
+    Universe,
+    Contribute, 
+    Donations, 
+    TabComponentJS, 
+    TabsWrapper 
+  },
   data: () => ({
     activeMode: 'main',
     modes: {
       main: 'Main',
       notes: 'Release Notes / Changelog',
       greenfire: 'Greenfire',
+      universe: 'Universe',
       contribute: 'Contribute',
       donations: 'Donations'
     },
@@ -165,7 +180,23 @@ export default {
   padding-bottom: 0;
 
   :deep(.tabs-wrapper) {
-    gap: 0.5rem;
+    gap: 0.25rem;
+    justify-content: space-between;
+  }
+  
+  :deep(.tab-icon) {
+    width: 16px;
+    height: 16px;
+    vertical-align: middle;
+    margin-right: 4px;
+    margin-top: -2px;
+    display: inline-block;
+  }
+  
+  .universe-tab {
+    display: inline-flex;
+    align-items: center;
+    white-space: nowrap;
   }
 }
 

--- a/src/components/global/TabComponentJS.vue
+++ b/src/components/global/TabComponentJS.vue
@@ -35,10 +35,12 @@ export default {
 
 <style lang="scss" scoped>
 .tab-component {
-  padding: 0.75rem 1.5rem;
+  padding: 0.75rem 1.25rem;
   cursor: pointer;
   border-bottom: 2px solid transparent;
   transition: all 0.3s ease;
+  font-size: 0.9rem;
+  white-space: nowrap;
   
   &:hover {
     background-color: #f3f4f6;

--- a/src/components/modals/about/Universe.vue
+++ b/src/components/modals/about/Universe.vue
@@ -1,0 +1,182 @@
+<template>
+  <div class="universe-container">
+    <h3 class="text-lg font-semibold text-center mb-4">Greenfire Universe</h3>
+    
+    <div class="projects-grid">
+      <!-- Greenfire -->
+      <div class="project-card" @click="openUrl('https://greenfire.io')">
+        <div class="logo-container">
+          <img src="/assets/icons/greenfire/greenfire.svg" alt="Greenfire Logo" class="project-logo" />
+        </div>
+        <div class="project-info">
+          <h4 class="project-title">Greenfire</h4>
+          <p class="project-description">Bridging the cryptocurrency ecosystem with the real world</p>
+          <div class="project-url">https://greenfire.io</div>
+        </div>
+      </div>
+      
+      <!-- Greenery -->
+      <div class="project-card" @click="openUrl('https://greenery.finance')">
+        <div class="logo-container">
+          <img src="/assets/icons/greenfire/greenery.svg" alt="Greenery Logo" class="project-logo" />
+        </div>
+        <div class="project-info">
+          <h4 class="project-title">Greenery</h4>
+          <p class="project-description">A cryptocurrency bookkeeping and accounting wallet</p>
+          <div class="project-url">https://greenery.finance</div>
+        </div>
+      </div>
+      
+      <!-- Techmarkets -->
+      <div class="project-card" @click="openUrl('https://techmarkets.io')">
+        <div class="logo-container">
+          <img src="/assets/icons/greenfire/greenfire.svg" alt="Techmarkets Logo" class="project-logo" />
+        </div>
+        <div class="project-info">
+          <h4 class="project-title">Techmarkets</h4>
+          <p class="project-description">A marketplace to buy and sell electronics with crypto</p>
+          <div class="project-url">https://techmarkets.io</div>
+        </div>
+      </div>
+      
+      <!-- Redacted -->
+      <div class="project-card redacted">
+        <div class="logo-container">
+          <div class="redacted-logo">?</div>
+        </div>
+        <div class="project-info">
+          <h4 class="project-title">*Redacted*</h4>
+          <p class="project-description">Coming soon...</p>
+          <div class="project-url">*Redacted*</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'UniverseView',
+  methods: {
+    openUrl(url) {
+      // Use electron shell to open external URL
+      if (window.shell) {
+        window.shell.openExternal(url);
+      } else if (window.open) {
+        window.open(url, '_blank');
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.universe-container {
+  padding: 0.5rem 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+h3 {
+  margin-bottom: 0.75rem !important;
+}
+
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  grid-template-rows: repeat(2, 1fr);
+  gap: 1rem;
+  flex: 1;
+  margin-top: 0.5rem;
+}
+
+.project-card {
+  display: flex;
+  border: 1px solid #e5e5e5;
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  height: 100%;
+  overflow: hidden;
+  
+  &:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    transform: translateY(-2px);
+    border-color: #5cba47;
+  }
+  
+  &.redacted {
+    opacity: 0.7;
+    cursor: default;
+    
+    &:hover {
+      box-shadow: none;
+      transform: none;
+      border-color: #e5e5e5;
+    }
+  }
+}
+
+.logo-container {
+  flex: 0 0 50px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 0.25rem;
+}
+
+.project-logo {
+  width: 40px;
+  height: 40px;
+}
+
+.redacted-logo {
+  width: 40px;
+  height: 40px;
+  background-color: #f0f0f0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  font-weight: bold;
+  color: #999;
+}
+
+.project-info {
+  flex: 1;
+  padding-left: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  min-width: 0; /* Allows text truncation to work */
+}
+
+.project-title {
+  font-weight: 600;
+  font-size: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.project-description {
+  font-size: 0.85rem;
+  color: #555;
+  flex: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.3;
+}
+
+.project-url {
+  font-size: 0.75rem;
+  color: #5cba47;
+  margin-top: 0.25rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style> 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

# About Modal Universe Tab PR

This PR adds a new "Universe" tab to the About modal, positioned between "Greenfire" and "Contribute" tabs. Key features:

- Created a 2x2 grid layout showcasing Greenfire ecosystem projects (Greenfire, Greenery, Techmarkets, and a redacted future project)
- Each card includes project logo, description, and clickable URL that opens in the default browser
- Added custom tab with inline Greenfire logo for better visual identification
- Optimized container sizes and text descriptions to eliminate scrolling
- Modified tab styling to ensure all tabs display in a single row

This enhancement improves user awareness of related Greenfire projects while maintaining the application's visual consistency.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] Build Out
- [ ] Import (From old Sparkplate)
- [ ] Import (From old Greenery)
- [x] Styling
- [x] New Feature
- [ ] New Function
- [x] Documentation update
- [ ] Other
