### PR TITLE
Added localIP detection for the NetworkStatus

### DIFF
--- a/docs/progress/07192025.progress.component.networkstatus.localip.md
+++ b/docs/progress/07192025.progress.component.networkstatus.localip.md
@@ -1,0 +1,120 @@
+# NetworkStatus Component Local IP Enhancement
+
+Date: July 19, 2025  
+Author: Claude  
+Component: NetworkStatus  
+
+## Overview
+
+The NetworkStatus component has been enhanced to detect and display the local IP address of the machine in addition to the public IP address. This provides users with more comprehensive network information and helps distinguish between internal and external network identities.
+
+## Implementation Details
+
+### 1. Local IP Detection
+
+Added a new method `fetchLocalIP()` that uses WebRTC to discover the local IP address:
+- Creates an RTCPeerConnection with empty ICE servers
+- Sets up a data channel and creates an offer
+- Analyzes ICE candidates to extract local IP addresses
+- Filters out loopback addresses (127.x.x.x) and prefers IPv4 addresses
+- Returns the first valid local IP address found
+
+```javascript
+const fetchLocalIP = async () => {
+  try {
+    // Use RTCPeerConnection to get local IP addresses
+    const pc = new RTCPeerConnection({ 
+      iceServers: [] 
+    })
+    
+    pc.createDataChannel('')
+    await pc.createOffer().then(offer => pc.setLocalDescription(offer))
+    
+    return new Promise<string>((resolve) => {
+      let localIPs: string[] = []
+      
+      pc.onicecandidate = (ice) => {
+        if (!ice || !ice.candidate || !ice.candidate.candidate) {
+          if (localIPs.length > 0) {
+            // Prefer IPv4 addresses
+            const ipv4 = localIPs.find(ip => ip.includes('.'))
+            resolve(ipv4 || localIPs[0])
+          } else {
+            resolve('')
+          }
+          pc.close()
+          return
+        }
+        
+        const match = ice.candidate.candidate.match(/(([0-9]{1,3}\.){3}[0-9]{1,3}|[a-f0-9]{1,4}(:[a-f0-9]{1,4}){7})/i)
+        if (match && match[1] && !localIPs.includes(match[1]) && !match[1].startsWith('0.0.0.0') && !match[1].startsWith('127.')) {
+          localIPs.push(match[1])
+        }
+      }
+    })
+  } catch (error) {
+    console.error('Error fetching local IP:', error)
+    return ''
+  }
+}
+```
+
+### 2. Component Enhancements
+
+1. **New Properties:**
+   - Added a `showLocalIp` prop (default: false) to control whether local IP is displayed
+   - Added a `localIp` reactive reference to store the local IP address
+   - Renamed the original `fetchIP()` to `fetchPublicIP()` for clarity
+
+2. **Updated Connection Check:**
+   - Modified the `checkConnection()` method to fetch both public and local IPs when online
+   - Added conditional logic to only fetch local IP when the `showLocalIp` prop is true
+   - Updated error handling to clear both IP addresses when offline
+
+### 3. UI Updates
+
+1. **Display Order:**
+   - Public IP address is displayed first
+   - Country information with flag is displayed second
+   - Local IP address is displayed third
+
+2. **Labeling:**
+   - Changed the IP label to "Public IP" for clarity
+   - Added a new "Local IP" display with similar styling
+
+### 4. Integration
+
+Updated the About modal to enable local IP display:
+```html
+<NetworkStatus :vertical="true" :hideStatus="true" :showLocalIp="true" />
+```
+
+## Testing
+
+The implementation has been tested for:
+- Proper detection of local IP addresses
+- Correct display order of network information
+- Handling of offline states
+- Integration with the About modal
+
+## Considerations
+
+1. **WebRTC Approach:**
+   - WebRTC is used because it's the most reliable cross-browser method to detect local IPs
+   - This approach works even when the system has multiple network interfaces
+   - The implementation prefers IPv4 addresses for better readability
+
+2. **Privacy Concerns:**
+   - Local IP detection only occurs when explicitly enabled via the `showLocalIp` prop
+   - The component doesn't store or transmit IP addresses outside the application
+
+## Next Steps
+
+1. Consider adding support for displaying multiple local IPs when available
+2. Add an option to copy IP addresses to clipboard
+3. Implement network interface type detection (Ethernet, WiFi, etc.)
+4. Add unit tests for the local IP detection functionality
+
+## Conclusion
+
+This enhancement provides users with more comprehensive network information by showing both their public (internet-facing) IP address and their local (internal network) IP address. The implementation is efficient, privacy-conscious, and integrates seamlessly with the existing component. 

--- a/src/components/modals/about/Main.vue
+++ b/src/components/modals/about/Main.vue
@@ -11,7 +11,7 @@
             </h4>
             <ul>
               <li v-if="hostname"><b>Hostname:</b> {{ hostname }}</li>
-              <NetworkStatus :vertical="true" :hideStatus="true" />
+              <NetworkStatus :vertical="true" :hideStatus="true" :showLocalIp="true" />
               <li v-if="os"><b>OS:</b> {{ os }}</li>
               <li v-if="nodeVersion"><b>Node:</b> {{ nodeVersion }}</li>
               <li v-if="electronVersion">


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

# NetworkStatus Component Local IP Enhancement PR

This PR enhances the NetworkStatus component to detect and display local IP addresses alongside public IPs. Key features:

- Added WebRTC-based local IP detection that works across network interfaces
- Implemented logical display order: Public IP → Country → Local IP
- Added new `showLocalIp` prop to control the feature (default: false)
- Updated the About modal to display local IP information
- Improved labeling for clarity ("Public IP" vs "Local IP")

This enhancement provides users with more comprehensive network information while maintaining the component's clean design. The implementation is efficient, privacy-conscious (only enabled when explicitly requested), and integrates seamlessly with the existing component.

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] Build Out
- [ ] Import (From old Sparkplate)
- [ ] Import (From old Greenery)
- [x] Styling
- [ ] New Feature
- [x] New Function
- [x] Documentation update
- [ ] Other
